### PR TITLE
Fix spelling

### DIFF
--- a/src/roman.py
+++ b/src/roman.py
@@ -64,7 +64,7 @@ romanNumeralMap = (('M', 1000),
 def toRoman(n):
     """convert integer to Roman numeral"""
     if not isinstance(n, int):
-        raise NotIntegerError("decimals can not be converted")
+        raise NotIntegerError("decimals cannot be converted")
     if not (-1 < n < 5000):
         raise OutOfRangeError("number out of range (must be 0..4999)")
 


### PR DESCRIPTION
Nowadays, "cannot" is spelled without space. See https://www.grammarphobia.com/blog/2019/08/cannot.html for details.